### PR TITLE
Add missing usings if namespace not starts with Havit

### DIFF
--- a/Facades/Infrastructure/DataSeedFacade.cs
+++ b/Facades/Infrastructure/DataSeedFacade.cs
@@ -1,4 +1,5 @@
-﻿using Havit.Data.Patterns.DataSeeds;
+﻿using Havit;
+using Havit.Data.Patterns.DataSeeds;
 using Havit.Data.Patterns.DataSeeds.Profiles;
 using Havit.Extensions.DependencyInjection.Abstractions;
 using Havit.NewProjectTemplate.Contracts;

--- a/JobsRunner/Program.cs
+++ b/JobsRunner/Program.cs
@@ -74,7 +74,7 @@ public static class Program
 						.UseFilter(new ContinuationsSupportAttribute(new HashSet<string> { FailedState.StateName, DeletedState.StateName, SucceededState.StateName })) // only valid with AutomaticRetryAttribute with Attempts = 0
 						.UseFilter(new CancelRecurringJobWhenAlreadyInQueueOrCurrentlyRunningFilter())
 						.UseFilter(new ExceptionMonitoringAttribute(serviceProvider.GetRequiredService<IExceptionMonitoringService>()))
-						.UseFilter(new ApplicationInsightAttribute(serviceProvider.GetRequiredService<TelemetryClient>()) { JobNameFunc = backgroundJob => Hangfire.Extensions.Helpers.JobNameHelper.TryGetSimpleName(backgroundJob.Job, out string simpleName) ? simpleName : backgroundJob.Job.ToString() })
+						.UseFilter(new ApplicationInsightAttribute(serviceProvider.GetRequiredService<TelemetryClient>()) { JobNameFunc = backgroundJob => Havit.Hangfire.Extensions.Helpers.JobNameHelper.TryGetSimpleName(backgroundJob.Job, out string simpleName) ? simpleName : backgroundJob.Job.ToString() })
 						.UseConsole()
 					);
 


### PR DESCRIPTION
If target "final" namespace not starts with Havit, some usings are missing.